### PR TITLE
シンプルリストが崩れていたので修正

### DIFF
--- a/src/components/atoms/PreviewText.vue
+++ b/src/components/atoms/PreviewText.vue
@@ -21,7 +21,7 @@
         {{ text }}
       </text>
       <text
-        x="50%"
+        :x="positionX"
         :text-anchor="textAnchor"
         :y="parseInt(font.fontSize, 10) * 0.92"
         :font-family="font.font"

--- a/src/components/organisms/previewSimpleListSchedule.vue
+++ b/src/components/organisms/previewSimpleListSchedule.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="preview-box-schedule">
-    <div class="preview-box-schedule_item">
+    <div class="preview-box-schedule_item --date">
       <preview-simple-list-item
         v-show="isShowDayOfWeek"
         class="preview-box-schedule_item-box"
@@ -137,6 +137,9 @@ export default defineComponent({
     }
     &-box.--time {
       margin-left: 30px;
+    }
+    &.--date {
+      width: 150px;
     }
   }
   & + & {


### PR DESCRIPTION
プレビューのテキストで左詰め時に縁取り用とメインの文字の位置がずれていたので修正。
月跨ぎのときに予定の開始位置がずれていたので修正。