### PR TITLE
fix: リストのデザインの修正

### DIFF
--- a/src/components/atoms/PreviewText.vue
+++ b/src/components/atoms/PreviewText.vue
@@ -3,10 +3,7 @@
     :class="{ 'display-middle': display === 'middle' }"
     :style="{ height: parseInt(font.fontSize, 10) * 1.1 + 'px' }"
   >
-    <svg
-      :width="parseInt(font.fontSize, 10) * (text.length + 1)"
-      :height="parseInt(font.fontSize, 10) * 1.1"
-    >
+    <svg :viewBox="viewBox" :height="parseInt(font.fontSize, 10) + 2">
       <text
         :x="positionX"
         :text-anchor="textAnchor"
@@ -76,18 +73,25 @@ export default defineComponent({
 
     const positionX = computed(() => {
       if (props.display === "left") {
-        return "0";
+        return "5";
       } else if (props.display === "right") {
         return "100%";
       } else return "50%";
     });
     const fontWeight = computed(() => (props.font.isBold ? "bold" : "normal"));
 
+    const viewBox = computed(() => {
+      return `0 0 ${props.font.fontSize * props.text.length + 10} ${
+        props.font.fontSize * 1 + 5
+      }`;
+    });
+
     return {
       stroke,
       textAnchor,
       positionX,
       fontWeight,
+      viewBox,
     };
   },
 });

--- a/src/components/molecules/previewListItem.vue
+++ b/src/components/molecules/previewListItem.vue
@@ -76,7 +76,5 @@ export default defineComponent({
     align-items: center;
     justify-content: center;
   }
-  &.--dayOfWeek {
-  }
 }
 </style>

--- a/src/components/organisms/previewListSchedule.vue
+++ b/src/components/organisms/previewListSchedule.vue
@@ -17,21 +17,21 @@
         :font="dateFont"
       />
     </div>
-    <div class="preview-box-schedule_item">
+    <div class="preview-box-schedule_schedules">
       <div
         v-for="(item, index) in schedules"
         :key="index"
-        class="preview-box-schedule_schedule-item --flex"
+        class="preview-box-schedule_schedule"
       >
         <preview-simple-list-item
-          class="preview-box-schedule_item-box"
+          class="preview-box-schedule_schedule-text"
           :text="item.text"
           :background="item.background"
           :font="item.font"
         />
         <preview-simple-list-item
           v-show="item.isShowTime"
-          class="preview-box-schedule_item-box --time"
+          class="preview-box-schedule_schedule-time"
           :text="`${item.time
             .getHours()
             .toString()
@@ -159,6 +159,26 @@ export default defineComponent({
   }
   &_background-gray {
     background: $color-right-gray-transparent;
+  }
+  &_schedules {
+    width: 100%;
+    margin-left: 25px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  &_schedule {
+    display: flex;
+    justify-content: space-between;
+    &-text {
+      width: 80%;
+    }
+    &-time {
+      width: 20%;
+    }
+    & + & {
+      margin-top: 10px;
+    }
   }
 }
 </style>

--- a/src/components/organisms/previewSimpleListSchedule.vue
+++ b/src/components/organisms/previewSimpleListSchedule.vue
@@ -15,21 +15,21 @@
         :font="dateFont"
       />
     </div>
-    <div class="preview-box-schedule_item">
+    <div class="preview-box-schedule_schedules">
       <div
         v-for="(item, index) in schedules"
         :key="index"
-        class="preview-box-schedule_schedule-item --flex"
+        class="preview-box-schedule_schedule-item"
       >
         <preview-simple-list-item
-          class="preview-box-schedule_item-box"
+          class="preview-box-schedule_schedule-title"
           :text="item.text"
           :background="item.background"
           :font="item.font"
         />
         <preview-simple-list-item
           v-show="item.isShowTime"
-          class="preview-box-schedule_item-box --time"
+          class="preview-box-schedule_start-time"
           :text="`${item.time
             .getHours()
             .toString()
@@ -121,10 +121,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.--flex {
-  display: flex;
-  justify-content: flex-start;
-}
 .preview-box-schedule {
   padding: 0 10px;
   display: flex;
@@ -135,17 +131,35 @@ export default defineComponent({
     & > * + * {
       margin-top: 10px;
     }
-    &-box.--time {
-      margin-left: 30px;
-    }
     &.--date {
-      width: 150px;
+      min-width: 140px;
     }
   }
   & + & {
     margin-top: 15px;
-    border-top: 3px solid #505050;
+    border-top: 3px solid $color-border;
     padding-top: 15px;
+  }
+  &_schedules {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: calc(100% - 140px);
+  }
+  &_schedule-item {
+    display: flex;
+    justify-content: space-between;
+    & + & {
+      margin-top: 5px;
+      border-top: 1px solid $color-border;
+      padding-top: 8px;
+    }
+  }
+  &_schedule-title {
+    width: 80%;
+  }
+  &_start-time {
+    width: 20%;
   }
 }
 </style>

--- a/src/style/color.scss
+++ b/src/style/color.scss
@@ -5,3 +5,4 @@ $color-right-gray: #e4e4e4;
 $color-right-gray-transparent: #e4e4e480;
 $color-blue: #2ca9de;
 $color-red: #ee4c3d;
+$color-border: #00000080;;


### PR DESCRIPTION
リストデザインで予定と開始時刻の隙間が固定ではなかったため、display: flex;で自動的に調整されるようにしました。